### PR TITLE
Adding the connectivity between users and challenges to enable challenge participation

### DIFF
--- a/src/main/java/com/example/levelup/Enums/ParticipationStatus.java
+++ b/src/main/java/com/example/levelup/Enums/ParticipationStatus.java
@@ -1,0 +1,6 @@
+package com.example.levelup.Enums;
+
+public enum ParticipationStatus {
+    ACTIVE,
+    COMPLETED
+}

--- a/src/main/java/com/example/levelup/Keys/ParticipationId.java
+++ b/src/main/java/com/example/levelup/Keys/ParticipationId.java
@@ -1,0 +1,19 @@
+package com.example.levelup.Keys;
+import jakarta.persistence.Embeddable;
+import lombok.Data;
+
+import java.io.Serializable;
+@Embeddable
+@Data
+public class ParticipationId implements Serializable {
+    private int challengeId;
+    private int userId;
+
+    public ParticipationId() {
+    }
+
+    public ParticipationId(int challengeId, int userId) {
+        this.challengeId = challengeId;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/example/levelup/models/Challenge.java
+++ b/src/main/java/com/example/levelup/models/Challenge.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Entity
@@ -29,5 +30,8 @@ public class Challenge {
     @ManyToOne
     @JoinColumn(name = "creator_id")
     private User creator;
+
+    @OneToMany(mappedBy = "challenge")
+    private List<Participation> participants;
 
 }

--- a/src/main/java/com/example/levelup/models/Participation.java
+++ b/src/main/java/com/example/levelup/models/Participation.java
@@ -1,0 +1,42 @@
+package com.example.levelup.models;
+
+import com.example.levelup.Enums.ParticipationStatus;
+import com.example.levelup.Keys.ParticipationId;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Table(name = "participates")
+public class Participation {
+
+    @EmbeddedId
+    private ParticipationId id;
+
+    @ManyToOne
+    @MapsId("challengeId")
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
+
+    @ManyToOne
+    @MapsId("userId")
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name="invited_by")
+    private int invitedBy;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ParticipationStatus status;
+
+    @Column(name = "progress")
+    private int progress;
+
+
+}

--- a/src/main/java/com/example/levelup/models/User.java
+++ b/src/main/java/com/example/levelup/models/User.java
@@ -40,5 +40,8 @@ public class User {
     @OneToMany(mappedBy = "creator")
     private List<Challenge> createdChallenges;
 
+    @OneToMany(mappedBy = "user")
+    private List<Participation> participatingChallenges;
+
 
 }


### PR DESCRIPTION
Creating the join_table (participates) to enable the many-to-many relationship between users and challenges.
To ensure this connection I had to create a composite key (ParticipationId) and also for the column status which tracks whether the challenge is completed or is still active, I created an enum called ParticipationStatus with values (ACTIVE, COMPLETED).